### PR TITLE
v3.4.1 - Fix use of CSL model copy mechanism

### DIFF
--- a/.github/actions/build-lin/action.yml
+++ b/.github/actions/build-lin/action.yml
@@ -18,6 +18,9 @@ outputs:
   xpl-file-name:
     description: Path to the resulting xpl file
     value: ${{ steps.return.outputs.xpl-file-name }}
+  pdb-file-name:
+    description: Path to the resulting .debug.zip file (debug symbol info)
+    value: ${{ steps.return.outputs.pdb-file-name }}
 
 runs:
   using: "composite"
@@ -52,9 +55,23 @@ runs:
         echo Expected target build not found: "$TARGET_XPL"
         exit 1
       fi
+  - name: Extract symbol info
+    shell: bash
+    env:
+      TARGET_XPL: build-lin/${{ inputs.archFolder }}/${{ inputs.pluginName }}.xpl
+      TARGET_DBG: build-lin/${{ inputs.archFolder }}/${{ inputs.pluginName }}.xpl.debug
+      TARGET_PDB: build-lin/${{ inputs.archFolder }}/${{ inputs.pluginName }}.xpl.debug.zip
+    run: |
+      objcopy --only-keep-debug "$TARGET_XPL" "$TARGET_DBG"
+      strip --strip-debug --strip-unneeded "$TARGET_XPL"
+      objcopy --add-gnu-debuglink="$TARGET_DBG" "$TARGET_XPL"
+      zip -9 "$TARGET_PDB" "$TARGET_DBG"
   - name: Return Value
     id: return
     shell: bash
     env:
       TARGET_XPL: build-lin/${{ inputs.archFolder }}/${{ inputs.pluginName }}.xpl
-    run: echo "xpl-file-name=$(echo $TARGET_XPL)" >> $GITHUB_OUTPUT
+      TARGET_PDB: build-lin/${{ inputs.archFolder }}/${{ inputs.pluginName }}.xpl.debug.zip
+    run: |
+      echo "xpl-file-name=$(echo $TARGET_XPL)" >> $GITHUB_OUTPUT
+      echo "pdb-file-name=$(echo $TARGET_PDB)" >> $GITHUB_OUTPUT

--- a/.github/actions/build-mac/action.yml
+++ b/.github/actions/build-mac/action.yml
@@ -18,6 +18,9 @@ outputs:
   xpl-file-name:
     description: Path to the resulting xpl file
     value: ${{ steps.return.outputs.xpl-file-name }}
+  pdb-file-name:
+    description: Path to the resulting .dSYM.zip file (debug symbol info)
+    value: ${{ steps.return.outputs.pdb-file-name }}
 
 runs:
   using: "composite"
@@ -51,9 +54,23 @@ runs:
         echo Expected target build not found: "$TARGET_XPL"
         exit 1
       fi
+  - name: Extract symbol info
+    shell: bash
+    env:
+      TARGET_XPL: build-mac/${{ inputs.archFolder }}/${{ inputs.pluginName }}.xpl
+      TARGET_DSYM: build-mac/${{ inputs.archFolder }}/${{ inputs.pluginName }}.xpl.dSYM
+      TARGET_PDB: build-mac/${{ inputs.archFolder }}/${{ inputs.pluginName }}.xpl.dSYM.zip
+    run: |
+      dsymutil "$TARGET_XPL"
+      zip -9r "$TARGET_PDB" "$TARGET_DSYM"
+      rm -rf "$TARGET_DSYM"
+      strip -S "$TARGET_XPL"
   - name: Return Value
     id: return
     shell: bash
     env:
       TARGET_XPL: build-mac/${{ inputs.archFolder }}/${{ inputs.pluginName }}.xpl
-    run: echo "xpl-file-name=$(echo $TARGET_XPL)" >> $GITHUB_OUTPUT
+      TARGET_PDB: build-mac/${{ inputs.archFolder }}/${{ inputs.pluginName }}.xpl.dSYM.zip
+    run: |
+      echo "xpl-file-name=$(echo $TARGET_XPL)" >> $GITHUB_OUTPUT
+      echo "pdb-file-name=$(echo $TARGET_PDB)" >> $GITHUB_OUTPUT

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,7 @@ jobs:
   #####################################
   # Linux with GCC
   build-lin:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       platform: lin
     steps:
@@ -40,11 +40,12 @@ jobs:
         pluginName:   ${{ env.PRJ_NAME }}
         archFolder:   lin_x64
         xplFileName:  "${{ steps.build.outputs.xpl-file-name }}"
+        pdbFileName:  "${{ steps.build.outputs.pdb-file-name }}"
 
   #####################################
   # MacOS with CMake/clang and sign/notarize in self-written script
   build-mac:
-    runs-on: macos-12
+    runs-on: macos-14
     env:
       platform: mac
     steps:
@@ -85,6 +86,7 @@ jobs:
         pluginName:   ${{ env.PRJ_NAME }}
         archFolder:   mac_x64
         xplFileName:  ${{ steps.build.outputs.xpl-file-name }}
+        pdbFileName:  "${{ steps.build.outputs.pdb-file-name }}"
 
   #####################################
   # Windows with MS Visual Studio

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ else()
 endif()
 
 project(XPMP2RemoteClient
-        VERSION 3.4.0
+        VERSION 3.4.1
         DESCRIPTION "XPMP2-Remote client plugin for X-Plane")
 
 # Provide compile macros from the above project version definition

--- a/XPMP2-Remote.xcodeproj/project.pbxproj
+++ b/XPMP2-Remote.xcodeproj/project.pbxproj
@@ -364,7 +364,7 @@
 				XPLANE11_ROOT = "$(USER_APPS_DIR)/X-Plane/11";
 				XPMP2_RC_VER_MAJOR = 3;
 				XPMP2_RC_VER_MINOR = 4;
-				XPMP2_RC_VER_PATCH = 0;
+				XPMP2_RC_VER_PATCH = 1;
 				XPSDK_ROOT = lib/XPMP2/lib/SDK;
 			};
 			name = Debug;
@@ -473,7 +473,7 @@
 				XPLANE11_ROOT = "$(USER_APPS_DIR)/X-Plane/11";
 				XPMP2_RC_VER_MAJOR = 3;
 				XPMP2_RC_VER_MINOR = 4;
-				XPMP2_RC_VER_PATCH = 0;
+				XPMP2_RC_VER_PATCH = 1;
 				XPSDK_ROOT = lib/XPMP2/lib/SDK;
 			};
 			name = Release;

--- a/XPMP2-Remote.xcodeproj/project.pbxproj
+++ b/XPMP2-Remote.xcodeproj/project.pbxproj
@@ -361,7 +361,7 @@
 					"$(XPSDK_ROOT)/CHeaders/XPLM",
 					lib/XPMP2/inc,
 				);
-				XPLANE11_ROOT = "$(USER_APPS_DIR)/X-Plane/11";
+				XPLANE11_ROOT = "$(USER_APPS_DIR)/X-Plane/12";
 				XPMP2_RC_VER_MAJOR = 3;
 				XPMP2_RC_VER_MINOR = 4;
 				XPMP2_RC_VER_PATCH = 1;
@@ -470,7 +470,7 @@
 					"$(XPSDK_ROOT)/CHeaders/XPLM",
 					lib/XPMP2/inc,
 				);
-				XPLANE11_ROOT = "$(USER_APPS_DIR)/X-Plane/11";
+				XPLANE11_ROOT = "$(USER_APPS_DIR)/X-Plane/12";
 				XPMP2_RC_VER_MAJOR = 3;
 				XPMP2_RC_VER_MINOR = 4;
 				XPMP2_RC_VER_PATCH = 1;

--- a/XPMP2-Remote.xcodeproj/xcshareddata/xcschemes/XPMP2-Remote.xcscheme
+++ b/XPMP2-Remote.xcodeproj/xcshareddata/xcschemes/XPMP2-Remote.xcscheme
@@ -70,7 +70,7 @@
       allowLocationSimulation = "YES">
       <PathRunnable
          runnableDebuggingMode = "0"
-         FilePath = "/Users/birger/Applications/X-Plane/11/X-Plane.app">
+         FilePath = "/Users/birger/Applications/X-Plane/12/X-Plane.app">
       </PathRunnable>
    </LaunchAction>
    <ProfileAction

--- a/docs/readme.html
+++ b/docs/readme.html
@@ -77,11 +77,35 @@
 
     <h1>Release Notes</h1>
     
-    <h2>v3.4.0</h2>
+    <h2>v3.4.1</h2>
 
     <p><b>Update:</b> In case of doubt you can always just copy all files from the archive over the files of your existing installation.</p>
 
-    <p>At least copy the following files, which have changed compared to v1.10:</p>
+    <p>At least copy the following files, which have changed compared to v3.4.0:</p>
+    <ul>
+        <li><code>lin|mac|win_x64/XPMP2-Remote.xpl</code></li>
+        <li><code>Resources/Doc8643.txt</code></li>
+    </ul>
+
+    <p><strong>Note: On Windows</strong> you may need to update the Visual C++ redistributable by downloading and installing
+    <a href="https://aka.ms/vs/17/release/vc_redist.x64.exe">vc_redist.x64.exe</a> if XPMP2-Client does not start up.</p>
+
+    <P>Change log:</P>
+
+    <ul>
+        <li>
+            Fixed an error that caused the XPMP2-Remote client to use liveries not in line with the master
+            as it was not using the <a href="https://twinfan.github.io/XPMP2/CopyingObjFiles.html">object file enhancement functionality</a>.
+            This especially affected the X-CSL set of CSL models.
+            <a href="https://forums.x-plane.org/index.php?/forums/topic/328065-unable-to-resolve-x-csl-liveries-on-external-visual-machine-bluebell-works-correct/">See this forum thread</a>
+            for details.
+        </li>
+    </ul>
+
+
+    <h2>v3.4.0</h2>
+
+    <p>At least copy the following files, which have changed compared to v3.1.0:</p>
     <ul>
         <li><code>lin|mac|win_x64/XPMP2-Remote.xpl</code></li>
         <li><code>Resources/Doc8643.txt</code></li>
@@ -120,7 +144,7 @@
 
     <p><b>Update:</b> In case of doubt you can always just copy all files from the archive over the files of your existing installation.</p>
 
-    <p>At least copy the following files, which have changed compared to v1.10:</p>
+    <p>At least copy the following files, which have changed compared to v2.60:</p>
     <ul>
         <li><code>lin|mac|win_x64/XPMP2-Remote.xpl</code></li>
         <li><code>Resource/Contrail/</code> (<strong>new folder</strong> with 3 files:)</li>
@@ -143,7 +167,7 @@
 
     <h3>v2.60</h3>
 
-    <p>At least copy the following files, which have changed compared to v1.10:</p>
+    <p>At least copy the following files, which have changed compared to v1.20:</p>
     <ul>
         <li><code>lin|mac|win_x64/XPMP2-Remote.xpl</code></li>
     </ul>

--- a/src/Client.cpp
+++ b/src/Client.cpp
@@ -386,8 +386,8 @@ void ClientProcSettings (const std::uint32_t from[4],
         const XPMP2::RemoteMsgSettingsTy& otherS = itSender->second.settings;
         if (otherS.logLvl < rcGlob.mergedS.logLvl) rcGlob.mergedS.logLvl = otherS.logLvl;
         if ( otherS.bLogMdlMatch)               rcGlob.mergedS.bLogMdlMatch = true;
-        if ( otherS.bObjReplDataRefs)           rcGlob.mergedS.bLogMdlMatch = true;
-        if ( otherS.bObjReplTextures)           rcGlob.mergedS.bLogMdlMatch = true;
+        if ( otherS.bObjReplDataRefs)           rcGlob.mergedS.bObjReplDataRefs = true;
+        if ( otherS.bObjReplTextures)           rcGlob.mergedS.bObjReplTextures = true;
         if (!otherS.bLabelCutOffAtVisibility)   rcGlob.mergedS.bLabelCutOffAtVisibility = false;
         if ( otherS.bMapEnabled)                rcGlob.mergedS.bMapEnabled = true;
         if ( otherS.bMapLabels)                 rcGlob.mergedS.bMapLabels = true;


### PR DESCRIPTION
Please download from [X-Plane.org](https://forums.x-plane.org/index.php?/files/file/67797-xpmp2-remote-client/).

- Fixed an error that caused the XPMP2-Remote client to use liveries not in line with the master as it was not using the [object file enhancement functionality](https://twinfan.github.io/XPMP2/CopyingObjFiles.html). This especially affected the X-CSL set of CSL models. [See this forum thread](https://forums.x-plane.org/index.php?/forums/topic/328065-unable-to-resolve-x-csl-liveries-on-external-visual-machine-bluebell-works-correct/) for details.