### PR TITLE
v3.4.2 Fixes for XP 12.4.x

### DIFF
--- a/.github/actions/build-mac/action.yml
+++ b/.github/actions/build-mac/action.yml
@@ -25,10 +25,6 @@ outputs:
 runs:
   using: "composite"
   steps:
-  - name: Install required libs
-    shell: bash
-    run: |
-      brew install ninja
   - name: Prepare
     shell: bash
     run: |

--- a/.github/actions/upload-plugin/action.yml
+++ b/.github/actions/upload-plugin/action.yml
@@ -28,7 +28,7 @@ runs:
         mv "${{ inputs.pdbFileName }}" "deploy-${{ inputs.pluginName }}/${{ inputs.pluginName }}/${{ inputs.archFolder }}"
       fi
   - name: Upload plugin
-    uses: actions/upload-artifact@v4
+    uses: actions/upload-artifact@v6
     with:
       name: ${{ inputs.pluginName }}-${{ env.platform }}
       path: deploy-${{ inputs.pluginName }}/*   # this way the top folder in the artifacts is "MyPlugin"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
       platform: lin
     steps:
     - name: Checkout Code
-      uses: actions/checkout@v4       # must checkout before we can use our own actions
+      uses: actions/checkout@v5       # must checkout before we can use our own actions
       with:
         submodules: 'recursive'
     - name: Build
@@ -50,7 +50,7 @@ jobs:
       platform: mac
     steps:
     - name: Checkout Code
-      uses: actions/checkout@v4       # must checkout before we can use our own actions
+      uses: actions/checkout@v5       # must checkout before we can use our own actions
       with:
         submodules: 'recursive'
     - name: Build
@@ -96,7 +96,7 @@ jobs:
       platform: win
     steps:
     - name: Checkout Code
-      uses: actions/checkout@v4       # must checkout before we can use our own actions
+      uses: actions/checkout@v5       # must checkout before we can use our own actions
       with:
         submodules: 'recursive'
     - name: Build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ else()
 endif()
 
 project(XPMP2RemoteClient
-        VERSION 3.4.1
+        VERSION 3.4.2
         DESCRIPTION "XPMP2-Remote client plugin for X-Plane")
 
 # Provide compile macros from the above project version definition
@@ -114,13 +114,9 @@ else()
     if(MSVC)
         # Fast code, symbols into separate .pdb file, no global optimization (as it produces huge files)
         add_compile_options(/Zi /O2 /GL-)
-    elseif(APPLE)
-        add_compile_options(-O3 -fPIC)
-    elseif (UNIX OR MINGW)
-        # Use position-independent code and highest optimization level (FPS!).
-        add_compile_options(-O3 -fPIC)
-        # Strip symbols during linking
-        add_link_options(-s)
+    else()
+        # Use position-independent code and highest optimization level plus some minimal debug info for stack traces
+        add_compile_options(-O3 -fPIC -g1)
     endif()
 endif()
 

--- a/XPMP2-Remote.xcodeproj/xcshareddata/xcschemes/XPMP2-Remote.xcscheme
+++ b/XPMP2-Remote.xcodeproj/xcshareddata/xcschemes/XPMP2-Remote.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1410"
-   version = "1.3">
+   version = "2.0">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
@@ -63,15 +63,13 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
+      askForAppToLaunch = "Yes"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
-      allowLocationSimulation = "YES">
-      <PathRunnable
-         runnableDebuggingMode = "0"
-         FilePath = "/Users/birger/Applications/X-Plane/12/X-Plane.app">
-      </PathRunnable>
+      allowLocationSimulation = "YES"
+      launchAutomaticallySubstyle = "2">
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/docs/readme.html
+++ b/docs/readme.html
@@ -77,9 +77,39 @@
 
     <h1>Release Notes</h1>
     
-    <h2>v3.4.1</h2>
+    <h2>v3.4.2</h2>
 
+    <P>
+    <b>Mandatory Update for X-Plane 12.4.1</b> to prevent X-Plane from stopping.
+    </P>
+    
     <p><b>Update:</b> In case of doubt you can always just copy all files from the archive over the files of your existing installation.</p>
+
+    <p>At least copy the following files, which have changed compared to v3.4.1:</p>
+    <ul>
+        <li><code>lin|mac|win_x64/XPMP2-Remote.xpl</code></li>
+        <li><code>Resources/Doc8643.txt</code></li>
+    </ul>
+
+    <P>Change log:</P>
+
+    <ul>
+        <li>Fixed potential crashes in X-Plane 12.4.1 due to stricter SDK validations.</li>
+        <li>Fixed potential "Traffic plugin error...gave us target with no id" messages by XP 12.4.0.</li>
+        <li>Fixed a memory overrun in networking, which had the potential of
+            triggering crashes anywhere in X-Plane.</li>
+        <li>
+            Different transponder modes are derived and sent to X-Plane for
+            consideration in their improved TCAS displays. Certainly depends on
+            what the master sends.<br>
+            E.g. LiveTraffic sends for smaller aircraft
+            (wake turbulence category L and L/M) "Mode C"; for larger
+            ones "Mode S", and depending on location it further differentiates
+            between "GND", "TA-Only", and "TA/TR" mode.
+        </li>
+    </ul>
+
+    <h2>v3.4.1</h2>
 
     <p>At least copy the following files, which have changed compared to v3.4.0:</p>
     <ul>


### PR DESCRIPTION
- Fixed potential crashes in X-Plane 12.4.1 due to stricter SDK validations.
- Fixed potential "Traffic plugin error...gave us target with no id" messages by XP 12.4.0.
- Fixed a memory overrun in networking, which had the potential of triggering crashes anywhere in X-Plane.
- Different transponder modes are derived and sent to X-Plane for consideration in their improved TCAS displays. Certainly depends on what the master sends.
  E.g. LiveTraffic sends for smaller aircraft (wake turbulence category L and L/M) "Mode C"; for larger ones "Mode S", and depending on location it further differentiates between "GND", "TA-Only", and "TA/TR" mode.